### PR TITLE
Remove dev dependencies before use it for compile php extensions

### DIFF
--- a/php-fpm/Dockerfile
+++ b/php-fpm/Dockerfile
@@ -4,4 +4,6 @@ FROM php:7-fpm-alpine
 RUN apk add --no-cache postgresql-dev libmcrypt-dev icu-dev \
 	&& docker-php-ext-install pdo pdo_pgsql iconv mcrypt intl opcache mbstring 
 
+RUN apk del libmcrypt-dev icu-dev
+
 CMD ["php-fpm"]


### PR DESCRIPTION
Remove dev dependencies before use it for compile php extensions in Dockerfile